### PR TITLE
fix confused message when phantomjs is not exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "unittest"
   ],
   "dependencies": {
-    "win-spawn": "~2.0.0",
-    "mocha": "*",
     "commander": "*",
-    "node-static": "*"
+    "mocha": "*",
+    "node-static": "*",
+    "phantomjs": "^1.9.12",
+    "win-spawn": "~2.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@lepture, in this patch, I added phantomjs as dependency because i got a confusing message when i have no phantomjs installed globally:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:1001:11)
    at Process.ChildProcess._handle.onexit (child_process.js:792:34)
```
